### PR TITLE
Fix prayer timings retrieval to handle empty responses and set timing…

### DIFF
--- a/lambda/handlers/apiHandler.js
+++ b/lambda/handlers/apiHandler.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const helperFunctions = require("../helperFunctions");
 const mawaqitBaseUrl = process.env.baseUrl;
 
 const getMosqueList = async (
@@ -52,7 +53,7 @@ const getMosqueList = async (
     });
 };
 
-const getPrayerTimings = async (mosqueUuid, isIqamaCalendarRequired = false, isPrayerCalendarRequired = false) => {
+const getPrayerTimings = async (mosqueUuid, timezone, isIqamaCalendarRequired = false, isPrayerCalendarRequired = false) => {
   const config = getConfig("get", `/mosque/${mosqueUuid}/times`);
   console.log(
     "Config: ",
@@ -65,9 +66,18 @@ const getPrayerTimings = async (mosqueUuid, isIqamaCalendarRequired = false, isP
     .request(config)
     .then((response) => {
       console.log("Mosque Timings: ", JSON.stringify(response.data));
-      if (!response?.data?.times) {
+      const currentDate = new Date();
+      const dateAndMonth = helperFunctions.getDateAndMonthForTimezone(timezone);
+      const date = dateAndMonth?.date ?? currentDate.getDate();
+      const month = dateAndMonth?.month ?? currentDate.getMonth();
+      const calendar = response?.data?.calendar;
+      const timings = calendar?.[month]?.[String(date)];
+
+      if (!Array.isArray(calendar) || calendar.length === 0 || !timings) {
         throw new Error("Received Empty Response");
       }
+
+      response.data.times = timings;
       if (!isIqamaCalendarRequired && response?.data?.iqamaCalendar) {
         delete response.data.iqamaCalendar;
       }

--- a/lambda/handlers/intentHandler.js
+++ b/lambda/handlers/intentHandler.js
@@ -68,7 +68,8 @@ const SelectMosqueIntentAfterSelectingMosqueHandler = {
     );
     await handlerInput.attributesManager.savePersistentAttributes();
     try {
-      const mosqueTimes = await getPrayerTimings(selectedMosqueDetails.uuid);
+      const userTimeZone = await helperFunctions.getUserTimezone(handlerInput);
+      const mosqueTimes = await getPrayerTimings(selectedMosqueDetails.uuid, userTimeZone);
       sessionAttributes.mosqueTimes = mosqueTimes;
       handlerInput.attributesManager.setSessionAttributes(sessionAttributes);
       return await helperFunctions.getPrayerTimingsForMosque(
@@ -83,6 +84,12 @@ const SelectMosqueIntentAfterSelectingMosqueHandler = {
       console.log("Error in fetching prayer timings: ", error);
       if (error?.message === "Mosque not found") {
         return await helperFunctions.getListOfMosque(handlerInput, requestAttributes.t("mosqueNotRegisteredPrompt"));
+      }
+      if (error?.message === "Unable to fetch user timezone") {
+        return handlerInput.responseBuilder
+          .speak(requestAttributes.t("timezoneErrorPrompt"))
+          .withShouldEndSession(true)
+          .getResponse();
       }
       return handlerInput.responseBuilder
         .speak(requestAttributes.t("nextPrayerTimeErrorPrompt"))
@@ -312,6 +319,7 @@ const NextIqamaTimeIntentHandler = {
       }
       mosqueTimes.iqamaCalendar = await getPrayerTimings(
         persistentAttributes.uuid,
+        userTimeZone,
         true
       )
         .then((data) => data.iqamaCalendar)
@@ -523,6 +531,7 @@ const AllIqamaTimeIntentHandler = {
       }
       mosqueTimes.iqamaCalendar = await getPrayerTimings(
         persistentAttributes.uuid,
+        userTimeZone,
         true
       )
         .then((data) => data.iqamaCalendar)
@@ -805,9 +814,11 @@ const PlayAdhanTaskHandler = {
         return await helperFunctions.checkForPersistenceData(handlerInput);
       }
       let { mosqueTimes } = sessionAttributes;
+        
+      const userTimeZone = await helperFunctions.getUserTimezone(handlerInput);
       if (!mosqueTimes?.times) {
         try {
-          mosqueTimes = await getPrayerTimings(persistentAttributes.uuid);
+          mosqueTimes = await getPrayerTimings(persistentAttributes.uuid, userTimeZone);
           sessionAttributes.mosqueTimes = mosqueTimes;
           handlerInput.attributesManager.setSessionAttributes(sessionAttributes);
         } catch (error) {
@@ -820,7 +831,7 @@ const PlayAdhanTaskHandler = {
       }
       let audioName = "Adhaan";
       const prayerNames = requestAttributes.t("prayerNames");
-      const prayerTimeDetails = helperFunctions.getNextPrayerTime(requestAttributes, mosqueTimes.times, await helperFunctions.getUserTimezone(handlerInput), prayerNames);
+      const prayerTimeDetails = helperFunctions.getNextPrayerTime(requestAttributes, mosqueTimes.times, userTimeZone, prayerNames);
       const isFajrPrayer = prayerTimeDetails.name === prayerNames[0];
       let audioUrl = isFajrPrayer ? adhaanRecitation[0].fajrUrl : adhaanRecitation[0].otherUrl;
       if(persistentAttributes?.favouriteAdhaan){

--- a/lambda/handlers/prayerTimeWidgetHandler.js
+++ b/lambda/handlers/prayerTimeWidgetHandler.js
@@ -18,8 +18,8 @@ const InstallPrayerTimeWidgetRequestHandler = {
                 .getResponse();
         }
         try {
-            const mosqueTimes = await apiHandler.getPrayerTimings(persistentAttributes.uuid);
             const userTimeZone = await helperFunctions.getUserTimezone(handlerInput);
+            const mosqueTimes = await apiHandler.getPrayerTimings(persistentAttributes.uuid, userTimeZone);
             const prayerNames = requestAttributes.t("prayerNames");
             const nextPrayerTime = helperFunctions.getNextPrayerTime(
                 requestAttributes,

--- a/lambda/handlers/touchHandler.js
+++ b/lambda/handlers/touchHandler.js
@@ -31,7 +31,8 @@ const MosqueListTouchEventHandler = {
     );
     await handlerInput.attributesManager.savePersistentAttributes();
     try {
-      const mosqueTimes = await getPrayerTimings(selectedMosque.uuid);
+      const userTimeZone = await helperFunctions.getUserTimezone(handlerInput);
+      const mosqueTimes = await getPrayerTimings(selectedMosque.uuid, userTimeZone);
       sessionAttributes.mosqueTimes = mosqueTimes;
       handlerInput.attributesManager.setSessionAttributes(sessionAttributes);
       return await helperFunctions.getPrayerTimingsForMosque(
@@ -43,6 +44,12 @@ const MosqueListTouchEventHandler = {
       console.log("Error in fetching prayer timings: ", error);
       if (error?.message === "Mosque not found") {
         return await helperFunctions.getListOfMosque(handlerInput, requestAttributes.t("mosqueNotRegisteredPrompt"));
+      }
+       if (error?.message === "Unable to fetch user timezone") {
+        return handlerInput.responseBuilder
+          .speak(requestAttributes.t("timezoneErrorPrompt"))
+          .withShouldEndSession(true)
+          .getResponse();
       }
       return handlerInput.responseBuilder
         .speak(requestAttributes.t("nextPrayerTimeErrorPrompt"))

--- a/lambda/helperFunctions.js
+++ b/lambda/helperFunctions.js
@@ -891,6 +891,17 @@ const isNewSession = (handlerInput) => {
   return handlerInput.requestEnvelope?.session?.new;
 };
 
+const getDateAndMonthForTimezone = (timezone) => {
+  if (!timezone || !moment.tz.zone(timezone)) return null;
+
+  const now = moment().tz(timezone);
+  const date = now.date();
+  const month = now.month();
+
+  return { date, month };
+};
+
+
 module.exports = {
   getPersistedData,
   checkForConsentTokenToAccessDeviceLocation,
@@ -930,5 +941,6 @@ module.exports = {
   getAplArgument,
   isNewSession,
   resolveIqamaMoment,
-  getDifferenceInMinutes
+  getDifferenceInMinutes,
+  getDateAndMonthForTimezone
 };

--- a/lambda/interceptors.js
+++ b/lambda/interceptors.js
@@ -183,7 +183,8 @@ async function processPersistentAttributes(handlerInput, persistentAttributes) {
   const sessionAttributes = handlerInput.attributesManager.getSessionAttributes();
 
   try {
-    const mosqueTimes = await apiHandler.getPrayerTimings(persistentAttributes.uuid);
+    const userTimeZone = await helperFunctions.getUserTimezone(handlerInput);
+    const mosqueTimes = await apiHandler.getPrayerTimings(persistentAttributes.uuid, userTimeZone);
     sessionAttributes.mosqueTimes = mosqueTimes;
     sessionAttributes.persistentAttributes = persistentAttributes;
     handlerInput.attributesManager.setSessionAttributes(sessionAttributes);
@@ -191,7 +192,12 @@ async function processPersistentAttributes(handlerInput, persistentAttributes) {
     console.log("Error while fetching mosque list: ", error);
     if (error?.message === "Mosque not found") {
       await handlerInput.attributesManager.deletePersistentAttributes();
-    }
+    } else if (error?.message === "Unable to fetch user timezone") {
+      // Timezone unavailable: still load persistentAttributes into session so
+      // handlers can display the correct mosque context and prompt for timezone consent.
+      sessionAttributes.persistentAttributes = persistentAttributes;
+      handlerInput.attributesManager.setSessionAttributes(sessionAttributes);
+     }
   }
 }
 


### PR DESCRIPTION
…s correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prayer timings and related widgets/tasks (including adhan playback and touch interactions) are now timezone-aware for more accurate local times.

* **Bug Fixes**
  * Improved validation and fallback when using prayer calendars to avoid empty or incorrect timing responses.
  * Clearer user prompt and graceful handling when the app cannot determine the user’s timezone.

* **Chores**
  * Added a timezone utility and updated flows to pass timezone context when fetching prayer timings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->